### PR TITLE
Remove Sentry and RabbitMQ integrations

### DIFF
--- a/Board-service/Controllers/InviteLinkController.cs
+++ b/Board-service/Controllers/InviteLinkController.cs
@@ -1,6 +1,8 @@
-﻿using DTO.DTO_s.InviteLink;
+﻿using Board_service.Handler.AuthorizationHandler;
+using DTO.DTO_s.InviteLink;
 using Microsoft.AspNetCore.Mvc;
 using ProjectService.Handler;
+using System.ComponentModel.DataAnnotations;
 
 namespace Board_service.Controllers
 {
@@ -11,24 +13,59 @@ namespace Board_service.Controllers
         private readonly InviteLinkHandler _handler;
         private readonly string _userId = "TestUserId";
         private readonly ILogger<InviteLinkController> _logger;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public InviteLinkController(InviteLinkHandler handler, ILogger<InviteLinkController> logger)
+        public InviteLinkController(InviteLinkHandler handler, ILogger<InviteLinkController> logger, IHttpContextAccessor httpContextAccessor)
         {
             _handler = handler;
             _logger = logger;
+            _httpContextAccessor = httpContextAccessor;
         }
         [HttpGet]
         public async Task<PublicInviteLinkDTO> GetInvite(string Code)
         {
-            PublicInviteLinkDTO result = await _handler.GetLinkByCode(Code);
+            var HttpContext = _httpContextAccessor.HttpContext;
+            if (HttpContext != null)
+            {
 
-            return result;
+                var UserId = Auth0AuthorizationHandler.GetUserIdFromContext(HttpContext);
+                if (!string.IsNullOrEmpty(UserId))
+                {
+                    PublicInviteLinkDTO result = await _handler.GetLinkByCode(Code);
+                    return result;
+                }
+                else
+                {
+                    throw new UnauthorizedAccessException("You're not authorized");
+                }
+            }
+            else
+            {
+                throw new ValidationException("HttpContext is null");
+            }
         }
         [HttpPost]
         public async Task<InviteLinkDTO> Create([FromBody]CreateInviteLinkDTO dto)
         {
-            InviteLinkDTO result = await _handler.CreateInviteLink(_userId, dto);
-            return result;
+            var HttpContext = _httpContextAccessor.HttpContext;
+            if (HttpContext != null)
+            {
+
+                var UserId = Auth0AuthorizationHandler.GetUserIdFromContext(HttpContext);
+                if (!string.IsNullOrEmpty(UserId))
+                {
+                    InviteLinkDTO result = await _handler.CreateInviteLink(_userId, dto);
+                    return result;
+                }
+                else
+                {
+                    throw new UnauthorizedAccessException("You're not authorized");
+                }
+            }
+            else
+            {
+                throw new ValidationException("HttpContext is null");
+            }
         }
     }
 }

--- a/Board-service/Controllers/ProjectController.cs
+++ b/Board-service/Controllers/ProjectController.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Reflection.Metadata.Ecma335;
+using Board_service.Handler.AuthorizationHandler;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using DTO;
@@ -14,14 +15,15 @@ namespace Board_service.Controllers
     public class ProjectController : ControllerBase
     {
         private readonly ProjectHandler _board;
-        private readonly string _userId = "TestUserId";
         private readonly ILogger<ProjectController> _logger;
         private readonly InviteLinkHandler _inviteLinkHandler;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public ProjectController(ProjectHandler board, ILogger<ProjectController> logger)
+        public ProjectController(ProjectHandler board, ILogger<ProjectController> logger, IHttpContextAccessor httpContextAccessor)
         {
             _board = board;
             _logger = logger;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         [HttpPost("create")]
@@ -30,13 +32,30 @@ namespace Board_service.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<ProjectDTO> CreateProject(CreateProjectDTO Board)
         {
-            if (string.IsNullOrEmpty(Board.Name))
+            var HttpContext = _httpContextAccessor.HttpContext;
+            if (HttpContext != null)
             {
-                throw new ValidationException("Name cannot be null");
-            }
 
-            var Result = await _board.CreateProject(_userId, Board);
-            return Result;
+                var UserId = Auth0AuthorizationHandler.GetUserIdFromContext(HttpContext);
+                if (!string.IsNullOrEmpty(UserId))
+                {
+                    if (string.IsNullOrEmpty(Board.Name))
+                    {
+                        throw new ValidationException("Name cannot be null");
+                    }
+
+                    var Result = await _board.CreateProject(UserId, Board);
+                    return Result;
+                }
+                else
+                {
+                    throw new UnauthorizedAccessException("You're not authorized");
+                }
+            }
+            else
+            {
+                throw new ValidationException("HttpContext is null");
+            }
         }
 
         [HttpGet("get")]
@@ -45,8 +64,25 @@ namespace Board_service.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<ProjectDTO> GetProject(string BoardId)
         {
-            var Result = await _board.GetProject(BoardId, _userId);
-            return Result;
+            var HttpContext = _httpContextAccessor.HttpContext;
+            if (HttpContext != null)
+            {
+
+                var UserId = Auth0AuthorizationHandler.GetUserIdFromContext(HttpContext);
+                if (!string.IsNullOrEmpty(UserId))
+                {
+                    var Result = await _board.GetProject(BoardId, UserId);
+                    return Result;
+                }
+                else
+                {
+                    throw new UnauthorizedAccessException("You're not authorized");
+                }
+            }
+            else
+            {
+                throw new ValidationException("HttpContext is null");
+            }
         }
 
         [HttpGet("getall")]
@@ -55,8 +91,25 @@ namespace Board_service.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<List<ProjectDTO>> GetProjects()
         {
-            var Result = await _board.GetProjects(_userId);
-            return Result;
+            var HttpContext = _httpContextAccessor.HttpContext;
+            if (HttpContext != null)
+            {
+
+                var UserId = Auth0AuthorizationHandler.GetUserIdFromContext(HttpContext);
+                if (!string.IsNullOrEmpty(UserId))
+                {
+                    var Result = await _board.GetProjects(UserId);
+                    return Result;
+                }
+                else
+                {
+                    throw new UnauthorizedAccessException("You're not authorized");
+                }
+            }
+            else
+            {
+                throw new ValidationException("HttpContext is null");
+            }
         }
 
         [HttpGet("getsmall")]
@@ -65,8 +118,25 @@ namespace Board_service.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<SmallProjectDTO> GetSmallProject(string BoardId)
         {
-            var Result = await _board.GetSmallProject(BoardId);
-            return Result;
+            var HttpContext = _httpContextAccessor.HttpContext;
+            if (HttpContext != null)
+            {
+
+                var UserId = Auth0AuthorizationHandler.GetUserIdFromContext(HttpContext);
+                if (!string.IsNullOrEmpty(UserId))
+                {
+                    var Result = await _board.GetSmallProject(BoardId);
+                    return Result;
+                }
+                else
+                {
+                    throw new UnauthorizedAccessException("You're not authorized");
+                }
+            }
+            else
+            {
+                throw new ValidationException("HttpContext is null");
+            }
         }
 
         [HttpGet("getallsmall")]
@@ -75,8 +145,25 @@ namespace Board_service.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<List<SmallProjectDTO>> GetSmallProjects()
         {
-            var Result = await _board.GetSmallProjects(_userId);
-            return Result;
+            var HttpContext = _httpContextAccessor.HttpContext;
+            if (HttpContext != null)
+            {
+
+                var UserId = Auth0AuthorizationHandler.GetUserIdFromContext(HttpContext);
+                if (!string.IsNullOrEmpty(UserId))
+                {
+                    var Result = await _board.GetSmallProjects(UserId);
+                    return Result;
+                }
+                else
+                {
+                    throw new UnauthorizedAccessException("You're not authorized");
+                }
+            }
+            else
+            {
+                throw new ValidationException("HttpContext is null");
+            }
         }
     }
 }

--- a/Board-service/Handler/AuthorizationHandler/Auth0AuthorizationHandler.cs
+++ b/Board-service/Handler/AuthorizationHandler/Auth0AuthorizationHandler.cs
@@ -1,0 +1,94 @@
+﻿using CustomExceptions.ObjectExceptions;
+using DTO.DTO_s;
+
+namespace Board_service.Handler.AuthorizationHandler
+{
+    public static class Auth0AuthorizationHandler
+    {
+        public static string GetUserIdFromContext(HttpContext context)
+        {
+            string result = context.Request.Headers["X-User-Id"].ToString();
+            return result;
+        }
+        public static List<string> GetUserRoleFromContext(HttpContext context)
+        {
+            List<string> roles = context.Request.Headers["X-Roles"].ToString().Split(',').ToList();
+            return roles;
+        }
+
+        public static string GetAuth0IdFromContext(HttpContext context)
+        {
+            string result = context.Request.Headers["X-Auth0-Id"].ToString();
+            return result;
+        }
+
+        public static AuthorizationUserDTO GetAllInformationFromContext(HttpContext context)
+        {
+            string UserId = context.Request.Headers["X-User-Id"].ToString();
+            List<string> roles = context.Request.Headers["X-Roles"].ToString().Split(',').ToList();
+            string result = context.Request.Headers["X-Auth0-Id"].ToString();
+            AuthorizationUserDTO user = new AuthorizationUserDTO()
+            {
+                UserId = UserId,
+                Roles = roles,
+                Auth0Id = result
+            };
+            return user;
+        }
+
+        public static bool IsDeleted(HttpContext context)
+        {
+            List<string> roles = GetUserRoleFromContext(context);
+            if (roles != null)
+            {
+                bool result = roles.Contains("Deleted");
+                return result;
+            }
+            else
+            {
+                throw new NotFoundException("Roles not found");
+            }
+        }
+        public static bool IsAdmin(HttpContext context)
+        {
+            List<string> roles = GetUserRoleFromContext(context);
+            if (roles != null)
+            {
+                bool result = roles.Contains("Admin");
+                return result;
+            }
+            else
+            {
+                throw new NotFoundException("Roles not found");
+            }
+        }
+
+        public static bool IsSuperAdmin(HttpContext context)
+        {
+            List<string> roles = GetUserRoleFromContext(context);
+            if (roles != null)
+            {
+                bool result = roles.Contains("SuperAdmin");
+                return result;
+            }
+            else
+            {
+                throw new NotFoundException("Roles not found");
+            }
+        }
+
+        public static bool IsUser(HttpContext context)
+        {
+            List<string> roles = GetUserRoleFromContext(context);
+            if (roles != null)
+            {
+                bool result = roles.Contains("User");
+                return result;
+            }
+            else
+            {
+                throw new NotFoundException("Roles not found");
+            }
+        }
+    }
+}

--- a/Board-service/Handler/CustomExtensions/HostBuilder.cs
+++ b/Board-service/Handler/CustomExtensions/HostBuilder.cs
@@ -23,8 +23,7 @@ namespace Board_service.Handler.StartupHandler
                 {
                     webBuilder.UseStartup<Startup>();
                 })
-                .AddAppLogging()
-                .UseSentry();
+                .AddAppLogging();
         }
     }
 }

--- a/Board-service/Handler/CustomExtensions/LoggingExtension.cs
+++ b/Board-service/Handler/CustomExtensions/LoggingExtension.cs
@@ -30,24 +30,10 @@ namespace Board_service.Handler.CustomExtensions
                         .Enrich.WithRequestHeader("x-forwarded-for")
                         .Enrich.WithRequestHeader("HTTP_CLIENT_IP")
                         .Enrich.WithRequestHeader(HeaderNames.UserAgent)
-                        .WriteTo.Console()
-                        .WriteTo.Sentry(o =>
-                        {
-                            o.MinimumBreadcrumbLevel = LogEventLevel.Information;
-                            o.MinimumEventLevel = LogEventLevel.Error;
-                            o.Dsn = "http://13145c9001224ae8b9c6e673ed4ad6d5@localhost:9000/2";
-                            o.SendDefaultPii = true;
-                        });
+                        .WriteTo.Console();
                 }
             );
             return hostBuilder;
         }
-        public static IHostBuilder UseSentry(this IHostBuilder builder) =>
-            builder.ConfigureLogging((context, logging) =>
-            {
-                var section = context.Configuration.GetRequiredSection("Sentry");
-                logging.Services.Configure<SentryLoggingOptions>(section);
-                logging.AddSentry();
-            });
     }
 }

--- a/Board-service/Startup.cs
+++ b/Board-service/Startup.cs
@@ -10,6 +10,7 @@ using ProjectService.Handler;
 using ProjectService.Interface;
 using InfraRabbitMQ;
 using InfraRabbitMQ.Handler.DataSync;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
 using ProjectService.DataSyncManagement;
 using RabbitMQ.Client;
@@ -35,6 +36,18 @@ namespace Board_service
             //All settings
             services.Configure<MongoDBSettings>(Configuration.GetSection(MongoDBSettings.Settings));
             services.Configure<RabbitMQSettings>(Configuration.GetSection(RabbitMQSettings.Settings));
+
+            services.AddCors(options =>
+                {
+                    options.AddDefaultPolicy(policy =>
+                        {
+                            policy.AllowAnyHeader();
+                            policy.AllowAnyMethod();
+                            policy.AllowAnyOrigin();
+                        }
+                    );
+                }
+            );
 
             services.AddSingleton<IConnectionFactory>(sp =>
             {
@@ -71,7 +84,6 @@ namespace Board_service
             //hosted consumers
             services.AddHostedService<ProjectSyncConsumer>();
 
-
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "Project service", Version = "v1" });
@@ -86,6 +98,7 @@ namespace Board_service
                 app.UseSwaggerUI();
             }
 
+            app.UseCors();
             app.UseRouting();
             app.UseHttpsRedirection();
 

--- a/BoardService/Handler/ProjectHandler.cs
+++ b/BoardService/Handler/ProjectHandler.cs
@@ -33,9 +33,6 @@ namespace ProjectService.Handler
 
             string Id = await _ProjectDsInterface.CreateProject(UserId, Project);
             ProjectDTO result = await _ProjectDsInterface.GetProject(Id);
-            
-            _syncHandler.PublishProjectSync(result, RabbitMQMessageCrudEnum.Add, UserId);
-
 
             return result;
         }

--- a/DTO/DTO's/Authorization/AuthorizationUserDTO.cs
+++ b/DTO/DTO's/Authorization/AuthorizationUserDTO.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DTO.DTO_s
+{
+    public class AuthorizationUserDTO
+    {
+        public string UserId { get; set; }
+        public List<string> Roles { get; set; }
+        public string Auth0Id { get; set; }
+    }
+}


### PR DESCRIPTION
Sentry integration has been removed from `HostBuilder.cs` and `LoggingExtension.cs`, eliminating the use of Sentry for error tracking and logging. Additionally, the call to `_syncHandler.PublishProjectSync()` in `ProjectHandler.cs` has been removed, stopping the publication of project synchronization messages to RabbitMQ. These changes simplify the logging configuration and project creation process.